### PR TITLE
Add git repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.3",
   "main": "./index.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:kevinfaguiar/cool-emoji-picker.git"
+  },
   "keywords": [
     "emoji-data",
     "twemoji",


### PR DESCRIPTION
This way the GitHub link also shows up on the package's `npm` page 🙌 
(on the right-hand sidebar).